### PR TITLE
Eliminate busy loop to get data back from DepthAI

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -41,5 +41,5 @@ fi
 
 # Be sure to use `exec` so that termination signals reach the python process,
 # or handle forwarding termination signals manually
-echo "$LOG_PREFIX Starting module..."
+echo "$LOG_PREFIX Starting module."
 exec $PYTHON -m src.main $@

--- a/src/oak_d.py
+++ b/src/oak_d.py
@@ -52,6 +52,7 @@ VALID_ATTRIBUTES = ["height_px", "width_px", "sensors", "frame_rate", "debug"]
 MAX_HEIGHT = 1080
 MAX_WIDTH = 1920
 MAX_FRAME_RATE = 60
+MAX_GRPC_BYTE_COUNT = 4194304  # Update this if the gRPC config ever changes (RSDK-5632)
 
 DEFAULT_FRAME_RATE = 30
 DEFAULT_WIDTH = 640
@@ -316,7 +317,6 @@ class OakDModel(Camera, Reconfigurable, Stoppable):
             reconfigure=callback,
             logger=LOGGER,
         )
-        cls.worker.start()
 
     def stop(
         self,
@@ -367,7 +367,11 @@ class OakDModel(Camera, Reconfigurable, Stoppable):
         mime_type = self._validate_get_image_mime_type(mime_type)
         cls: OakDModel = type(self)
 
+        if not cls.worker.running:
+            raise ViamError("get_image called before camera worker was ready.")
+
         main_sensor = self.sensors[0]
+
         if main_sensor == COLOR_SENSOR:
             if mime_type == CameraMimeType.JPEG:
                 captured_data = await cls.worker.get_color_image()
@@ -407,8 +411,15 @@ class OakDModel(Camera, Reconfigurable, Stoppable):
                   The metadata associated with this response
         """
         cls: OakDModel = type(self)
+
+        if not cls.worker.running:
+            raise ViamError("get_images called before camera worker was ready.")
+
+        # Accumulator for images
         l: List[NamedImage] = []
+        # Accumulator for timestamp calculation later
         seconds_float: float = None
+
         if COLOR_SENSOR in self.sensors:
             captured_data = await cls.worker.get_color_image()
             arr, captured_at = captured_data.np_array, captured_data.captured_at
@@ -427,6 +438,7 @@ class OakDModel(Camera, Reconfigurable, Stoppable):
             img = NamedImage("color", jpeg_encoded_bytes, CameraMimeType.JPEG)
             seconds_float = captured_at
             l.append(img)
+
         if DEPTH_SENSOR in self.sensors:
             captured_data = await cls.worker.get_depth_map()
             arr, captured_at = captured_data.np_array, captured_data.captured_at
@@ -436,6 +448,8 @@ class OakDModel(Camera, Reconfigurable, Stoppable):
             )
             seconds_float = captured_at
             l.append(img)
+
+        # Create timestamp for metadata
         seconds_int = int(seconds_float)
         nanoseconds_int = int((seconds_float - seconds_int) * 1e9)
         metadata = ResponseMetadata(
@@ -478,12 +492,21 @@ class OakDModel(Camera, Reconfigurable, Stoppable):
             bytes: The serialized point cloud data.
             str: The mimetype of the point cloud (e.g. PCD).
         """
+        LOGGER.debug("Handling get point cloud call.")
+        # Validation
         if DEPTH_SENSOR not in self.sensors:
             details = 'Please include "depth" in the "sensors" attribute list.'
             raise MethodNotAllowed(method_name="get_point_cloud", details=details)
         cls = type(self)
+
+        if not cls.worker.running:
+            raise ViamError("get_point_cloud called before camera worker is ready.")
+
+        # Get actual PCD data from camera worker
         pcd_obj = await cls.worker.get_pcd()
         arr = pcd_obj.np_array
+
+        # Done with pre-processing; create and send message now:
         # TODO RSDK-5676: why do we need to normalize by 1000 when depthAI says they return depth in mm?
         flat_array = arr.reshape(-1, arr.shape[-1]) / 1000.0
         # TODO RSDK-5676: why do we need to negate the 1st and 2nd dimensions for image to be the correct orientation?
@@ -499,9 +522,19 @@ class OakDModel(Camera, Reconfigurable, Stoppable):
         width = f"WIDTH {len(flat_array)}\n"
         points = f"POINTS {len(flat_array)}\n"
         header = f"{version}{fields}{size}{type_of}{count}{width}{height}{viewpoint}{points}{data}"
-        h = bytes(header, "UTF-8")
-        a = np.array(flat_array, dtype="f")
-        return (h + a.tobytes(), CameraMimeType.PCD)
+        header_bytes = bytes(header, "UTF-8")
+        float_array = np.array(flat_array, dtype="f")
+
+        # Subsample if bytes payload > max
+        msg_byte_count = len(float_array.tobytes()) + len(header_bytes)
+        LOGGER.info(f"msg_byte_count: {msg_byte_count}")
+        if msg_byte_count > MAX_GRPC_BYTE_COUNT:
+            LOGGER.warning(
+                f"PCD bytes ({msg_byte_count}) > max message bytes count ({MAX_GRPC_BYTE_COUNT}). Subsampling data 0.5x."
+            )
+            float_array = float_array[::2, ::2, :]  # subsamples every other
+
+        return (header_bytes + float_array.tobytes(), CameraMimeType.PCD)
 
     async def get_properties(
         self, *, timeout: Optional[float] = None, **kwargs
@@ -525,19 +558,13 @@ class OakDModel(Camera, Reconfigurable, Stoppable):
         Returns:
             bytes: encoded bytes
         """
-        height, width = shape  # using np array shape for actual outputted height/width
+        height, width = shape  # using np shape for actual output's height/width
         MAGIC_NUMBER = struct.pack(
             ">Q", 4919426490892632400
-        )  # UTF-8 binary encoding for 'DEPTHMAP', big-endian
-        MAGIC_BYTE_COUNT = struct.calcsize(
-            "Q"
-        )  # Number of bytes used to represent the depth magic number
-        WIDTH_BYTE_COUNT = struct.calcsize(
-            "Q"
-        )  # Number of bytes used to represent depth image width
-        HEIGHT_BYTE_COUNT = struct.calcsize(
-            "Q"
-        )  # Number of bytes used to represent depth image height
+        )  # UTF-8 encoding for 'DEPTHMAP'
+        MAGIC_BYTE_COUNT = struct.calcsize("Q")
+        WIDTH_BYTE_COUNT = struct.calcsize("Q")
+        HEIGHT_BYTE_COUNT = struct.calcsize("Q")
 
         # Depth header contains 8 bytes for the magic number, followed by 8 bytes for width and 8 bytes for height. Each pixel has 2 bytes.
         pixel_byte_count = np.dtype(np.uint16).itemsize * width * height
@@ -547,13 +574,12 @@ class OakDModel(Camera, Reconfigurable, Stoppable):
             MAGIC_BYTE_COUNT + WIDTH_BYTE_COUNT + HEIGHT_BYTE_COUNT + pixel_byte_count
         )
         LOGGER.debug(
-            f"{MAGIC_BYTE_COUNT} + {WIDTH_BYTE_COUNT} + {HEIGHT_BYTE_COUNT} + {pixel_byte_count} = total_byte_count: {total_byte_count}"
+            f"Calculated size:  {MAGIC_BYTE_COUNT} + {WIDTH_BYTE_COUNT} + {HEIGHT_BYTE_COUNT} + {pixel_byte_count} = {total_byte_count}"
         )
-        LOGGER.debug(f"size of data: {len(data)}")
+        LOGGER.debug(f"Actual data size: {len(data)}")
 
         # Create a bytearray to store the encoded data
         raw_buf = bytearray(total_byte_count)
-
         offset = 0
 
         # Copy the depth magic number into the buffer

--- a/src/oak_d.py
+++ b/src/oak_d.py
@@ -587,10 +587,7 @@ class OakDModel(Camera, Reconfigurable, Stoppable):
         """
         # Guard for empty str (no inputted mime_type)
         if mime_type == "":
-            LOGGER.warning(
-                f"mime_type was empty str or null; defaulting to {CameraMimeType.JPEG}."
-            )
-            return CameraMimeType.JPEG
+            return CameraMimeType.JPEG  # default is JPEG
 
         # Get valid types based on main sensor
         main_sensor = self.sensors[0]

--- a/src/worker.py
+++ b/src/worker.py
@@ -8,38 +8,73 @@ from threading import Thread
 import cv2
 import depthai as dai
 from depthai_sdk import OakCamera
-from depthai_sdk.classes.packets import PointcloudPacket, DisparityDepthPacket
+from depthai_sdk.classes.packets import (
+    DisparityDepthPacket,
+    FramePacket,
+    PointcloudPacket,
+)
 from depthai_sdk.components.camera_component import CameraComponent
 from depthai_sdk.components.pointcloud_component import PointcloudComponent
 from depthai_sdk.components.stereo_component import StereoComponent
 from numpy.typing import NDArray
 
 
-PREVIEW_STREAM_NAME = "PREVIEW"
-MAX_PIPELINE_FAILURES = 3
-MAX_GRPC_MESSAGE_BYTE_COUNT = (
-    4194304  # Update this if the gRPC config ever changes (RSDK-5632)
-)
-CAM_RESOLUTION = dai.ColorCameraProperties.SensorResolution.THE_1080_P
+COLOR_CAM_RESOLUTION = dai.ColorCameraProperties.SensorResolution.THE_1080_P
+
+
+class WorkerManager(Thread):
+    """
+    WorkerManager checks the health of the OakCamera to make sure
+    it is physically connected and functioning in a separate thread.
+    """
+
+    def __init__(
+        self,
+        oak: OakCamera,
+        logger: Logger,
+        reconfigure: Callable[[None], None],
+    ) -> None:
+        self.oak = oak
+        self.logger = logger
+        self.reconfigure = reconfigure
+
+        self.running = True
+        super().__init__()
+
+    def run(self) -> None:
+        self.logger.debug("Starting worker manager.")
+        while self.running:
+            self.logger.debug("Checking if worker must be reconfigured.")
+            if self.oak.device.isClosed():
+                self.logger.debug("Camera is closed. Reconfiguring worker.")
+                self.reconfigure()
+                self.running = False
+            time.sleep(3)
+
+    def stop(self) -> None:
+        self.logger.debug("Stopping worker manager.")
+        self.running = False
 
 
 class CapturedData:
-    """CapturedData is the data as an np array, plus the time.time() it was captured at."""
+    """
+    CapturedData is image data with the data as an np array,
+    plus the time.time() it was captured at.
+    """
 
     def __init__(self, np_array: NDArray, captured_at: float) -> None:
         self.np_array = np_array
         self.captured_at = captured_at
 
 
-class Worker(Thread):
+class Worker:
     """
-    OakDModel class <-> Worker <-> DepthAI SDK <-> DepthAI API (C++) <-> the actual OAK-D camera
+    OakDModel <-> Worker <-> DepthAI SDK <-> DepthAI API (C++ core) <-> actual OAK-D
     """
 
     color_image: Union[CapturedData, None]
     depth_map: Union[CapturedData, None]
     pcd: Union[CapturedData, None]
-    get_pcd_was_invoked: bool
 
     def __init__(
         self,
@@ -65,194 +100,145 @@ class Worker(Thread):
         self.depth_map = None
         self.pcd = None
         self.running = True
-        self.get_pcd_was_invoked = False
-        super().__init__()
+
+        self._init_oak_camera()
+        color = self._configure_color()
+        stereo = self._configure_stereo(color)
+        self._configure_pc(stereo, color)
+        self.oak.start()
+
+        self.manager = WorkerManager(self.oak, logger, reconfigure)
+        self.manager.start()
 
     async def get_color_image(self) -> CapturedData:
         while not self.color_image and self.running:
             self.logger.debug("Waiting for color image...")
-            await asyncio.sleep(1)
+            await asyncio.sleep(0.01)
         return self.color_image
 
     async def get_depth_map(self) -> CapturedData:
         while not self.depth_map and self.running:
             self.logger.debug("Waiting for depth map...")
-            await asyncio.sleep(1)
+            await asyncio.sleep(0.01)
         return self.depth_map
 
     async def get_pcd(self) -> CapturedData:
-        if not self.get_pcd_was_invoked:
-            self.get_pcd_was_invoked = True
         while not self.pcd and self.running:
             self.logger.debug("Waiting for pcd...")
-            await asyncio.sleep(1)
+            await asyncio.sleep(0.01)
         return self.pcd
 
-    def _pipeline_loop(self) -> None:
-        """
-        Initializes the integration with DepthAI using OakCamera API. It builds the pipeline
-        and reads from output queues and polls callback functions to get camera data.
-        """
-        failures = 0
-        try:
-            self.logger.debug("Initializing worker image pipeline.")
-            with OakCamera() as oak:
-                color = self._configure_color(oak)
-                stereo = self._configure_stereo(oak, color)
-                self._configure_pc(oak, stereo, color)
-                previous_get_pcd_was_invoked = self.get_pcd_was_invoked
-                oak.start()
-                while self.running:
-                    if previous_get_pcd_was_invoked != self.get_pcd_was_invoked:
-                        break  # to restart pipeline with PCD support
-                    self._handle_color_output(oak)
-                    self._handle_depth_and_pcd_output(oak)
-        except Exception as e:
-            failures += 1
-            if failures > MAX_PIPELINE_FAILURES:
-                self.logger.error(
-                    f"Reached {MAX_PIPELINE_FAILURES} max failures in pipeline loop. Error: {e}"
-                )
-                self.logger.debug("Worker needs reconfiguring; reconfiguring worker.")
-                self.reconfigure()
-                self.stop()
-            else:
-                self.logger.debug(
-                    f"Pipeline loop failure count: {failures}. Error: {e}. "
-                )
-        finally:
-            self.logger.debug("Exiting worker pipeline loop.")
-
-    def run(self) -> None:
-        """
-        Implements `run` of the Thread protocol. (Re)starts and (re)runs the pipeline loop
-        according to the worker manager.
-        """
-        try:
-            while self.running:
-                self._pipeline_loop()
-        finally:
-            self.logger.info("Stopped and exited worker thread.")
-
     def stop(self) -> None:
-        """Implements `stop` of the Thread protocol."""
+        """
+        Handles stopping and closing of the camera worker.
+        """
         self.logger.info("Stopping worker.")
-        self.running = False
+        self.manager.stop()
+        self.oak.close()
 
-    def _configure_color(self, oak: OakCamera) -> Union[CameraComponent, None]:
+    def _init_oak_camera(self):
+        """
+        Blocks until the OakCamera is successfully initialized.
+        """
+        self.oak = None
+        while not self.oak:
+            try:
+                self.oak = OakCamera()
+            except Exception as e:
+                self.logger.error(f"Error starting OakCamera: {e}")
+                time.sleep(1)
+
+    def _configure_color(self) -> Union[CameraComponent, None]:
         """
         Creates and configures color component— or doesn't
         (based on the config).
-
-        Args:
-            oak (OakCamera)
 
         Returns:
             Union[CameraComponent, None]
         """
         if self.user_wants_color:
             self.logger.debug("Creating pipeline node: color camera.")
-            xout_color = oak.pipeline.create(dai.node.XLinkOut)
-            xout_color.setStreamName(PREVIEW_STREAM_NAME)
-            color = oak.camera("color", fps=self.frame_rate, resolution=CAM_RESOLUTION)
-            # setPreviewSize sets the closest supported resolution
-            # inputted height width may not be respected
+            color = self.oak.camera(
+                "color", fps=self.frame_rate, resolution=COLOR_CAM_RESOLUTION
+            )
+            # Size setting in DepthAI sets the closest supported resolution
+            # Inputted height width may not be respected
             color.node.setPreviewSize(self.width, self.height)
-            color.node.preview.link(xout_color.input)
+            color.node.setVideoSize(self.width, self.height)
+            self.oak.callback(color, callback=self._set_color_image)
             return color
         return None
 
     def _configure_stereo(
-        self, oak: OakCamera, color: CameraComponent
+        self, color: Union[CameraComponent, None]
     ) -> Union[StereoComponent, None]:
         """
         Creates and configures stereo depth component— or doesn't
         (based on the config).
-
-        Args:
-            oak (OakCamera)
 
         Returns:
             Union[StereoComponent, None]
         """
         if self.user_wants_depth:
             self.logger.debug("Creating pipeline node: stereo depth.")
-            # TODO RSDK-5633: Figure out how to use DepthAI to adjust the output size of depth maps.
+            # TODO RSDK-5633: Figure out how to use DepthAI to adjust depth output size.
             # Right now it's being handled as a manual crop resize in _set_depth_map.
-            # The below commented code should fix this, but DepthAI hasn't implemented config_camera for mono cameras yet.
+            # The below commented out code should fix this
+            # ... but DepthAI hasn't implemented config_camera for mono cameras yet.
             # mono_left = oak.camera(dai.CameraBoardSocket.LEFT, fps=self.frame_rate)
             # mono_left.config_camera((self.width, self.height))
             # mono_right = oak.camera(dai.CameraBoardSocket.RIGHT, fps=self.frame_rate)
             # mono_right.config_camera((self.width, self.height))
             # stereo = oak.stereo(fps=self.frame_rate, left=mono_left, right=mono_right)
-            stereo = oak.stereo(fps=self.frame_rate, resolution="max")
-            if self.user_wants_color:
-                stereo.config_stereo(
-                    align=color
-                )  # ensures alignment and output resolution are same for color and depth
+            stereo = self.oak.stereo(fps=self.frame_rate, resolution="max")
+            if color:
+                # Ensures camera alignment and output resolution are same for color and depth
+                stereo.config_stereo(align=color)
                 stereo.node.setOutputSize(*color.node.getPreviewSize())
-            oak.callback(stereo, callback=self._set_depth_map)
+            self.oak.callback(stereo, callback=self._set_depth_map)
             return stereo
         return None
 
     def _configure_pc(
-        self, oak: OakCamera, stereo: StereoComponent, color: CameraComponent
+        self, stereo: Union[StereoComponent, None], color: Union[CameraComponent, None]
     ) -> Union[PointcloudComponent, None]:
         """
         Creates and configures point cloud component— or doesn't
-        (based on the config and if the module has invoked get_pcd).
-
-        Args:
-            oak (OakCamera)
+        (based on the config)
 
         Returns:
             Union[PointcloudComponent, None]
         """
-        if self.user_wants_depth and self.get_pcd_was_invoked:
+        if self.user_wants_depth:
             self.logger.debug("Creating pipeline node: point cloud.")
-            pcc = oak.create_pointcloud(stereo, color)
-            oak.callback(pcc, callback=self._set_pcd)
+            pcc = self.oak.create_pointcloud(stereo, color)
+            self.oak.callback(pcc, callback=self._set_pcd)
             return pcc
         return None
 
-    def _handle_color_output(self, oak: OakCamera) -> None:
+    def _set_color_image(self, packet: FramePacket) -> None:
         """
-        Handles getting color image frames from preview stream
-        (not from direct out, for correct height and width). Does nothing
-        if the module is not configured to get color outputs.
+        Passed as a callback func to DepthAI to use when new color data is outputted.
+        Callback logic chronologically syncs all the outputted data.
 
         Args:
-            oak (OakCamera)
+            packet (FramePacket): outputted color data inputted by caller
         """
-        if self.user_wants_color:
-            rgb_queue = oak.device.getOutputQueue(PREVIEW_STREAM_NAME)
-            rgb_frame_data = rgb_queue.tryGet()
-            if rgb_frame_data:
-                bgr_frame = (
-                    rgb_frame_data.getCvFrame()
-                )  # OpenCV uses reversed (BGR) color order
-                rgb_frame = cv2.cvtColor(bgr_frame, cv2.COLOR_BGR2RGB)
-                self._set_color_image(rgb_frame)
-        return None
-
-    def _handle_depth_and_pcd_output(self, oak: OakCamera) -> None:
-        """
-        Handles polling OakCamera to get depth map and PCD (if configured). Does nothing
-        if the module is not configured to get depth outputs.
-
-        Args:
-            oak (OakCamera)
-        """
-        if self.user_wants_depth:
-            oak.poll()
-
-    def _set_color_image(self, arr: NDArray) -> None:
+        # DepthAI outputs BGR; convert to RGB
+        arr: NDArray = cv2.cvtColor(packet.frame, cv2.COLOR_BGR2RGB)
         self.logger.debug(
-            f"Setting current_image. Array shape: {arr.shape}. Dtype: {arr.dtype}"
+            f"Setting color image. Array shape: {arr.shape}. Dtype: {arr.dtype}"
         )
         self.color_image = CapturedData(arr, time.time())
 
     def _set_depth_map(self, packet: DisparityDepthPacket) -> None:
+        """
+        Passed as a callback func to DepthAI to use when new depth data is outputted.
+        Callback logic chronologically syncs all the outputted data.
+
+        Args:
+            packet (DisparityDepthPacket): outputted depth data inputted by caller
+        """
         arr = packet.frame
         if arr.shape != (self.height, self.width):
             self.logger.debug(
@@ -266,16 +252,18 @@ class Worker(Thread):
             ]
 
         self.logger.debug(
-            f"Setting current depth map. Array shape: {arr.shape}. Dtype: {arr.dtype}"
+            f"Setting depth map. Array shape: {arr.shape}. Dtype: {arr.dtype}"
         )
         self.depth_map = CapturedData(arr, time.time())
 
     def _set_pcd(self, packet: PointcloudPacket) -> None:
-        arr, num_bytes = packet.points, packet.points.nbytes
-        self.logger.debug(f"Setting current pcd. num_bytes: {num_bytes}")
-        if num_bytes > MAX_GRPC_MESSAGE_BYTE_COUNT:
-            self.logger.warning(
-                f"PCD bytes ({num_bytes}) > max gRPC bytes count ({MAX_GRPC_MESSAGE_BYTE_COUNT}). Subsampling data 0.5x."
-            )
-            arr = arr[::2, ::2, :]
+        """
+        Passed as a callback func to DepthAI to use when new PCD data is outputted.
+        Callback logic chronologically syncs all the outputted data.
+
+        Args:
+            packet (PointcloudPacket): outputted PCD data inputted by caller
+        """
+        arr, byte_count = packet.points, packet.points.nbytes
+        self.logger.debug(f"Setting pcd. Byte count: {byte_count}")
         self.pcd = CapturedData(arr, time.time())

--- a/src/worker.py
+++ b/src/worker.py
@@ -65,7 +65,6 @@ class Worker(Thread):
         self.depth_map = None
         self.pcd = None
         self.running = True
-        self.needs_reconfigure = False
         self.get_pcd_was_invoked = False
         super().__init__()
 
@@ -114,7 +113,9 @@ class Worker(Thread):
                 self.logger.error(
                     f"Reached {MAX_PIPELINE_FAILURES} max failures in pipeline loop. Error: {e}"
                 )
-                self.needs_reconfigure = True
+                self.logger.debug("Worker needs reconfiguring; reconfiguring worker.")
+                self.reconfigure()
+                self.stop()
             else:
                 self.logger.debug(
                     f"Pipeline loop failure count: {failures}. Error: {e}. "
@@ -130,12 +131,6 @@ class Worker(Thread):
         try:
             while self.running:
                 self._pipeline_loop()
-                if self.needs_reconfigure:
-                    self.logger.debug(
-                        "Worker needs reconfiguring; reconfiguring worker."
-                    )
-                    self.reconfigure()
-                    self.stop()
         finally:
             self.logger.info("Stopped and exited worker thread.")
 


### PR DESCRIPTION
Ok here's the plan:

1. Refactor pipeline loop into a pipeline instantiation

1. Set a self.oak and a self. color_queue in there

1. Change getters to read from output queue and poll the callbacks (may have to busy loop here but I think that's better than busy looping all the time by default). Can also investigate changing callback logic back to queue for at least depth.

1. Change actual loopy part to a health status check to see if we need to reconfigure. May have to pull back in the worker manager logic.