### PR TITLE
RSDK-5850 Remove all gRPC message limit checks

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -6,14 +6,14 @@ LOG_PREFIX="[Viam OAK-D local setup]"
 os=$(uname -s)
 arch=$(uname -m)
 
+appimage_path="./viam-camera-oak-d--aarch64.AppImage"
 # Run appimage if Linux aarch64
-if [ "$os" = "Linux" ] && [ "$arch" = "aarch64" ]; then
-    echo "$LOG_PREFIX Detected system Linux ARM64. Attempting to start appimage."
-    appimage_path="./viam-camera-oak-d--aarch64.AppImage"
+if [ "$os" = "Linux" ] && [ "$arch" = "aarch64" ] && [ -f "$appimage_path" ]; then
+    echo "$LOG_PREFIX Detected system Linux ARM64 and appimage. Attempting to start appimage."
     chmod +x "$appimage_path"
     exec "$appimage_path" "$@"
 else
-    echo "$LOG_PREFIX Detected system not Linux ARM64."
+    echo "$LOG_PREFIX Detected system not Linux ARM64 and no appimage."
 fi
 
 # Run from source if not Linux aarch64

--- a/src/oak_d.py
+++ b/src/oak_d.py
@@ -49,8 +49,6 @@ LOGGER = getLogger(__name__)
 
 VALID_ATTRIBUTES = ["height_px", "width_px", "sensors", "frame_rate"]
 
-MAX_GRPC_BYTE_COUNT = 4194304  # Update this if the gRPC config ever changes (RSDK-5632)
-
 # Be sure to update README.md if default attributes are changed
 DEFAULT_FRAME_RATE = 30
 DEFAULT_WIDTH = 640
@@ -504,16 +502,6 @@ class OakDModel(Camera, Reconfigurable, Stoppable):
         header = f"{version}{fields}{size}{type_of}{count}{width}{height}{viewpoint}{points}{data}"
         header_bytes = bytes(header, "UTF-8")
         float_array = np.array(flat_array, dtype="f")
-
-        # Subsample if bytes payload > max
-        msg_byte_count = len(float_array.tobytes()) + len(header_bytes)
-        LOGGER.debug(f"msg_byte_count: {msg_byte_count}")
-        if msg_byte_count > MAX_GRPC_BYTE_COUNT:
-            LOGGER.warning(
-                f"PCD bytes ({msg_byte_count}) > max message bytes count ({MAX_GRPC_BYTE_COUNT}). Subsampling data 0.5x."
-            )
-            float_array = float_array[::2, ::2, :]  # subsamples every other
-
         return (header_bytes + float_array.tobytes(), CameraMimeType.PCD)
 
     async def get_properties(


### PR DESCRIPTION
We decided that upholding gRPC message size maxes is out of scope of the module. Let's standardize that for get_point_cloud.

Also [sorry for the bad version control protocol, but I'm also gonna sneak in a small fix for the run.sh to allow the module to run from source code in aarch64 linux setups](https://github.com/viamrobotics/viam-camera-oak-d/pull/14/commits/8e189f245bd41865665b1968996fafac687373c2) 