### PR TITLE
Update requirements.txt to depend on current stable v of sdk

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 depthai-sdk==1.13.1
-viam-sdk
+viam-sdk==0.11.0


### PR DESCRIPTION
Good catch. I updated this to depend on the current stable version of the Python SDK.