### PR TITLE
RSDK-5840: Add error handling for DepthAI out of memory errors

### DIFF
--- a/src/oak_d.py
+++ b/src/oak_d.py
@@ -77,8 +77,8 @@ class OakDModel(Camera, Reconfigurable, Stoppable):
 
     It inherits from the built-in resource subtype Base and conforms to the
     ``Reconfigurable`` protocol, which signifies that this component can be
-    reconfigured. It also confirms to the ``Stoppable`` protocol, which signifies
-    that the component can be stopped manually using stop()
+    reconfigured. It also confirms to the `Stoppable` protocol, which signifies
+    that the component can be stopped manually using `stop`
 
     Additionally, it specifies a constructor function
     ``OakDModel.new`` which confirms to the ``resource.types.ResourceCreator``

--- a/src/worker.py
+++ b/src/worker.py
@@ -114,10 +114,7 @@ class Worker:
         self.running = True
 
         self._init_oak_camera()
-        color = self._configure_color()
-        stereo = self._configure_stereo(color)
-        self._configure_pc(stereo, color)
-        self.oak.start()
+        self._config_oak_camera()
 
         self.manager = WorkerManager(self.oak, logger, reconfigure)
         self.manager.start()
@@ -159,6 +156,19 @@ class Worker:
             except Exception as e:
                 self.logger.error(f"Error initializing OakCamera: {e}")
                 time.sleep(1)
+    
+    def _config_oak_camera(self):
+        """
+        Safely configure the OakCamera.
+        """        
+        try:
+            color = self._configure_color()
+            stereo = self._configure_stereo(color)
+            self._configure_pc(stereo, color)
+            self.oak.start()
+        except Exception as e:
+            self.logger.error(f"Error configuring OakCamera: {e}")
+            return
 
     def _get_closest_resolution(
         self,

--- a/src/worker.py
+++ b/src/worker.py
@@ -167,7 +167,10 @@ class Worker:
             self._configure_pc(stereo, color)
             self.oak.start()
         except Exception as e:
-            self.logger.error(f"Error configuring OakCamera: {e}")
+            err_str = f"Error configuring OakCamera: {e}"
+            if type(e) == RuntimeError and "bigger than maximum at current sensor resolution" in str(e):
+                err_str += ". Please adjust 'height_px' and 'width_px' in your config to an accepted resolution."
+            self.logger.error(err_str)
             return
 
     def _get_closest_resolution(

--- a/src/worker.py
+++ b/src/worker.py
@@ -156,11 +156,11 @@ class Worker:
             except Exception as e:
                 self.logger.error(f"Error initializing OakCamera: {e}")
                 time.sleep(1)
-    
+
     def _config_oak_camera(self):
         """
         Safely configure the OakCamera.
-        """        
+        """
         try:
             color = self._configure_color()
             stereo = self._configure_stereo(color)
@@ -168,7 +168,8 @@ class Worker:
             self.oak.start()
         except Exception as e:
             err_str = f"Error configuring OakCamera: {e}"
-            if type(e) == RuntimeError and "bigger than maximum at current sensor resolution" in str(e):
+            resolution_err_substr = "bigger than maximum at current sensor resolution"
+            if type(e) == RuntimeError and resolution_err_substr in str(e):
                 err_str += ". Please adjust 'height_px' and 'width_px' in your config to an accepted resolution."
             self.logger.error(err_str)
 

--- a/src/worker.py
+++ b/src/worker.py
@@ -171,7 +171,6 @@ class Worker:
             if type(e) == RuntimeError and "bigger than maximum at current sensor resolution" in str(e):
                 err_str += ". Please adjust 'height_px' and 'width_px' in your config to an accepted resolution."
             self.logger.error(err_str)
-            return
 
     def _get_closest_resolution(
         self,


### PR DESCRIPTION
This PR adds error handling for DepthAI out of memory errors

Goes from looking like:
`[18443010016B060F00] [1.1] [1.174] [StereoDepth(6)] [error] Out of memory while creating pool for 'depth' (aligned) frames. Number of frames: 3 each with size: 16588800B` uncaught

To looking like:
`\_ 2024-01-17 16:16:44,811		ERROR	src.oak_d (worker.py:173)	Error configuring OakCamera: ColorCamera(0) - 'video' width or height (9000, 9000) bigger than maximum at current sensor resolution (3840, 2160). Please adjust 'height_px' and 'width_px' in your config to an accepted resolution.` caught, and logged with red color with no extraneous logs.

It also improves error handling in general for configuring the OakCamera