### PR TITLE
RSDK-6385: Add clearer action for OAK-FFC 3P calibration errors

### DIFF
--- a/integration-tests/tests/all_test.go
+++ b/integration-tests/tests/all_test.go
@@ -26,18 +26,21 @@ const (
 )
 
 func TestCameraServer(t *testing.T) {
+	ctxTimeoutTests, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
 	var myRobot robot.Robot
 	var cam camera.Camera
 	t.Run("Set up the robot", func(t *testing.T) {
 		var err error
-		myRobot, err = setUpViamServer(context.Background(), t)
+		myRobot, err = setUpViamServer(ctxTimeoutTests, t)
 		test.That(t, err, test.ShouldBeNil)
 		cam, err = camera.FromRobot(myRobot, componentName)
 		test.That(t, err, test.ShouldBeNil)
 	})
 
 	t.Run("Get images method", func(t *testing.T) {
-		images, metadata, err := cam.Images(context.Background())
+		images, metadata, err := cam.Images(ctxTimeoutTests)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, images, test.ShouldNotBeNil)
 		test.That(t, metadata, test.ShouldNotBeNil)
@@ -51,7 +54,7 @@ func TestCameraServer(t *testing.T) {
 	})
 
 	t.Run("Get point cloud method", func(t *testing.T) {
-		pc, err := cam.NextPointCloud(context.Background())
+		pc, err := cam.NextPointCloud(ctxTimeoutTests)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, pc, test.ShouldNotBeNil)
 		test.That(t, pc.Size(), test.ShouldBeBetweenOrEqual, defaultHeight*defaultWidth-100, defaultHeight*defaultWidth)
@@ -63,16 +66,16 @@ func TestCameraServer(t *testing.T) {
 				"sensors": []string{"color"},
 			},
 		}
-		err := cam.Reconfigure(context.Background(), resource.Dependencies{}, cfg)
+		err := cam.Reconfigure(ctxTimeoutTests, resource.Dependencies{}, cfg)
 		test.That(t, err, test.ShouldBeNil)
 	})
 
 	t.Run("Shut down the camera", func(t *testing.T) {
-		test.That(t, cam.Close(context.Background()), test.ShouldBeNil)
+		test.That(t, cam.Close(ctxTimeoutTests), test.ShouldBeNil)
 	})
 
 	t.Run("Shut down the robot", func(t *testing.T) {
-		test.That(t, myRobot.Close(context.Background()), test.ShouldBeNil)
+		test.That(t, myRobot.Close(ctxTimeoutTests), test.ShouldBeNil)
 	})
 }
 

--- a/src/worker.py
+++ b/src/worker.py
@@ -171,11 +171,14 @@ class Worker:
             stage = "start"
             self.oak.start()
         except Exception as e:
-            err_str = f"Error configuring OakCamera at stage '{stage}': {e}"
+            msg = f"Error configuring OakCamera at stage '{stage}': {e}"
             resolution_err_substr = "bigger than maximum at current sensor resolution"
-            if type(e) == RuntimeError and resolution_err_substr in str(e):
-                err_str += ". Please adjust 'height_px' and 'width_px' in your config to an accepted resolution."
-            self.logger.error(err_str)
+            calibration_err_substr = "no Camera data available"
+            if resolution_err_substr in str(e):
+                msg += ". Please adjust 'height_px' and 'width_px' in your config to an accepted resolution."
+            elif calibration_err_substr in str(e):
+                msg += ". If using a non-integrated model, please check that the camera is calibrated properly."
+            self.logger.error(msg)
 
     def _get_closest_resolution(
         self,
@@ -261,14 +264,14 @@ class Worker:
                 self.oak.device,
                 self.oak.pipeline,
                 dai.CameraBoardSocket.CAM_B,  # Same as CameraBoardSocket.LEFT
-                dai.MonoCameraProperties.SensorResolution.THE_400_P,
+                resolution,
                 self.frame_rate,
             )
             cam_right = CameraComponent(
                 self.oak.device,
                 self.oak.pipeline,
                 dai.CameraBoardSocket.CAM_C,  # Same as CameraBoardSocket.RIGHT
-                dai.MonoCameraProperties.SensorResolution.THE_400_P,
+                resolution,
                 self.frame_rate,
             )
             stereo = self.oak.stereo(resolution, self.frame_rate, cam_left, cam_right)


### PR DESCRIPTION
Regardless of if we directly support Tennibot in calibrating their cameras, we should report better errors for uncalibrated cameras trying to get stereo outputs.

Error without improvements: `There is no Camera data available corresponding to the the requested source cameraId`

Error with improvements: `Error configuring OakCamera at stage 'point cloud': There is no Camera data available corresponding to the the requested source cameraId. If using a non-integrated model, please check that the camera is calibrated properly.`

Based on if we do end up implementing that CLI or simply pointing people to use Luxonis' docs, we can add onto this message accordingly.

Let me know if this all sounds good! TY