### PR TITLE
RSDK-6633: Derive get_images timestamps from DepthAI directly instead of time.time() inside our module

### DIFF
--- a/src/oak_d.py
+++ b/src/oak_d.py
@@ -1,5 +1,4 @@
 # Standard library
-import asyncio
 import io
 import logging
 import struct
@@ -355,14 +354,14 @@ class OakDModel(Camera, Reconfigurable, Stoppable):
 
         if main_sensor == COLOR_SENSOR:
             if mime_type == CameraMimeType.JPEG:
-                captured_data = await cls.worker.get_color_image()
+                captured_data = cls.worker.get_color_image()
                 return Image.fromarray(captured_data.np_array, "RGB")
             raise NotSupportedError(
                 f'mime_type "{mime_type}" is not supported for color. Please use {CameraMimeType.JPEG}'
             )
 
         if main_sensor == DEPTH_SENSOR:
-            captured_data = await cls.worker.get_depth_map()
+            captured_data = cls.worker.get_depth_map()
             arr = captured_data.np_array
             if mime_type == CameraMimeType.JPEG:
                 return Image.fromarray(arr, "I;16").convert("RGB")
@@ -410,7 +409,7 @@ class OakDModel(Camera, Reconfigurable, Stoppable):
 
         if COLOR_SENSOR in self.sensors:
             if color_data is None:
-                color_data: CapturedData = await cls.worker.get_color_image()
+                color_data: CapturedData = cls.worker.get_color_image()
             arr, captured_at = color_data.np_array, color_data.captured_at
             # Create a Pillow image from the raw data
             pil_image = Image.fromarray(arr)
@@ -429,7 +428,7 @@ class OakDModel(Camera, Reconfigurable, Stoppable):
 
         if DEPTH_SENSOR in self.sensors:
             if not depth_data:
-                depth_data: CapturedData = await cls.worker.get_depth_map()
+                depth_data: CapturedData = cls.worker.get_depth_map()
             arr, captured_at = depth_data.np_array, depth_data.captured_at
             depth_encoded_bytes = self._encode_depth_raw(arr.tobytes(), arr.shape)
             img = NamedImage(
@@ -502,7 +501,7 @@ class OakDModel(Camera, Reconfigurable, Stoppable):
             time.sleep(0.5)  # wait for new worker to initialize with pc configured
 
         # Get actual PCD data from camera worker
-        pcd_obj = await cls.worker.get_pcd()
+        pcd_obj = cls.worker.get_pcd()
         arr = pcd_obj.np_array
 
         # Done with pre-processing; create and send message now:

--- a/src/oak_d.py
+++ b/src/oak_d.py
@@ -371,6 +371,7 @@ class OakDModel(Camera, Reconfigurable, Stoppable):
             raise NotSupportedError(
                 f"mime_type {mime_type} is not supported for depth. Please use {CameraMimeType.JPEG} or {CameraMimeType.VIAM_RAW_DEPTH}."
             )
+
         raise ViamError(
             'get_image failed due to misconfigured "sensors" attribute, but should have been validated in `validate`...'
         )
@@ -405,7 +406,7 @@ class OakDModel(Camera, Reconfigurable, Stoppable):
         color_data: Optional(CapturedData) = None
         depth_data: Optional(CapturedData) = None
         if COLOR_SENSOR in self.sensors and DEPTH_SENSOR in self.sensors:
-            color_data, depth_data = await cls.worker.get_synced_color_depth_outputs()
+            color_data, depth_data = await cls.worker.get_synced_color_depth_data()
 
         if COLOR_SENSOR in self.sensors:
             if color_data is None:

--- a/src/oak_d.py
+++ b/src/oak_d.py
@@ -406,7 +406,7 @@ class OakDModel(Camera, Reconfigurable, Stoppable):
         color_data: Optional(CapturedData) = None
         depth_data: Optional(CapturedData) = None
         if COLOR_SENSOR in self.sensors and DEPTH_SENSOR in self.sensors:
-            color_data, depth_data = await cls.worker.get_synced_color_depth()
+            color_data, depth_data = await cls.worker.get_synced_color_depth_outputs()
 
         if COLOR_SENSOR in self.sensors:
             if color_data is None:

--- a/src/oak_d.py
+++ b/src/oak_d.py
@@ -403,7 +403,9 @@ class OakDModel(Camera, Reconfigurable, Stoppable):
         color_data: Optional(CapturedData) = None
         depth_data: Optional(CapturedData) = None
         if COLOR_SENSOR in self.sensors and DEPTH_SENSOR in self.sensors:
-            color_data, depth_data = await asyncio.gather(cls.worker.get_color_image(), cls.worker.get_depth_map())
+            color_data, depth_data = await asyncio.gather(
+                cls.worker.get_color_image(), cls.worker.get_depth_map()
+            )
             LOGGER.debug("color was captured at: " + str(color_data.captured_at))
             LOGGER.debug("depth was captured at: " + str(depth_data.captured_at))
 

--- a/src/oak_d.py
+++ b/src/oak_d.py
@@ -435,9 +435,9 @@ class OakDModel(Camera, Reconfigurable, Stoppable):
         if DEPTH_SENSOR in self.sensors:
             captured_at: CapturedData
             if depth_data:
-                captured_data = await cls.worker.get_depth_map()
-            else:
                 captured_data = depth_data
+            else:
+                captured_data = await cls.worker.get_depth_map()
 
             arr, captured_at = captured_data.np_array, captured_data.captured_at
             depth_encoded_bytes = self._encode_depth_raw(arr.tobytes(), arr.shape)

--- a/src/oak_d.py
+++ b/src/oak_d.py
@@ -403,11 +403,7 @@ class OakDModel(Camera, Reconfigurable, Stoppable):
         color_data: Optional(CapturedData) = None
         depth_data: Optional(CapturedData) = None
         if COLOR_SENSOR in self.sensors and DEPTH_SENSOR in self.sensors:
-            color_data, depth_data = await asyncio.gather(
-                cls.worker.get_color_image(), cls.worker.get_depth_map()
-            )
-            LOGGER.debug("color was captured at: " + str(color_data.captured_at))
-            LOGGER.debug("depth was captured at: " + str(depth_data.captured_at))
+            color_data, depth_data = await cls.worker.get_synced_color_depth()
 
         if COLOR_SENSOR in self.sensors:
             if color_data is None:

--- a/src/oak_d.py
+++ b/src/oak_d.py
@@ -494,7 +494,7 @@ class OakDModel(Camera, Reconfigurable, Stoppable):
 
         # By default, we do not get point clouds even when color and depth are both requested
         # We have to reinitialize the worker/OakCamera to start making point clouds
-        if cls.worker.pcd is None:
+        if not cls.worker.user_wants_pc:
             cls.get_point_cloud_was_invoked = True
             cls.worker.oak.close()  # triggers reconfigure callback
 

--- a/src/oak_d.py
+++ b/src/oak_d.py
@@ -410,13 +410,9 @@ class OakDModel(Camera, Reconfigurable, Stoppable):
             LOGGER.debug("depth was captured at: " + str(depth_data.captured_at))
 
         if COLOR_SENSOR in self.sensors:
-            captured_at: CapturedData
-            if color_data:
-                captured_data = color_data
-            else:
-                captured_data = await cls.worker.get_color_image()
-
-            arr, captured_at = captured_data.np_array, captured_data.captured_at
+            if color_data is None:
+                color_data: CapturedData = await cls.worker.get_color_image()
+            arr, captured_at = color_data.np_array, color_data.captured_at
             # Create a Pillow image from the raw data
             pil_image = Image.fromarray(arr)
 
@@ -433,13 +429,9 @@ class OakDModel(Camera, Reconfigurable, Stoppable):
             l.append(img)
 
         if DEPTH_SENSOR in self.sensors:
-            captured_at: CapturedData
-            if depth_data:
-                captured_data = depth_data
-            else:
-                captured_data = await cls.worker.get_depth_map()
-
-            arr, captured_at = captured_data.np_array, captured_data.captured_at
+            if not depth_data:
+                depth_data: CapturedData = await cls.worker.get_depth_map()
+            arr, captured_at = depth_data.np_array, depth_data.captured_at
             depth_encoded_bytes = self._encode_depth_raw(arr.tobytes(), arr.shape)
             img = NamedImage(
                 "depth", depth_encoded_bytes, CameraMimeType.VIAM_RAW_DEPTH

--- a/src/worker.py
+++ b/src/worker.py
@@ -302,7 +302,7 @@ class Worker:
     def _set_color_image(self, packet: FramePacket) -> None:
         """
         Passed as a callback func to DepthAI to use when new color data is outputted.
-        Callback logic chronologically syncs all the outputted data.
+        Callback logic chronologically syncs invocation of these _set functions.
 
         Args:
             packet (FramePacket): outputted color data inputted by caller
@@ -317,7 +317,7 @@ class Worker:
     def _set_depth_map(self, packet: DisparityDepthPacket) -> None:
         """
         Passed as a callback func to DepthAI to use when new depth data is outputted.
-        Callback logic chronologically syncs all the outputted data.
+        Callback logic chronologically syncs invocation of these _set functions.
 
         Args:
             packet (DisparityDepthPacket): outputted depth data inputted by caller
@@ -343,7 +343,7 @@ class Worker:
     def _set_pcd(self, packet: PointcloudPacket) -> None:
         """
         Passed as a callback func to DepthAI to use when new PCD data is outputted.
-        Callback logic chronologically syncs all the outputted data.
+        Callback logic chronologically syncs invocation of these _set functions.
 
         Args:
             packet (PointcloudPacket): outputted PCD data inputted by caller

--- a/src/worker.py
+++ b/src/worker.py
@@ -103,7 +103,7 @@ class MessageSynchronizer:
 class CapturedData:
     """
     CapturedData is image data with the data as an np array,
-    plus the time.time() it was captured at.
+    plus the timestamp it was captured at.
     """
 
     def __init__(self, np_array: NDArray, captured_at: float) -> None:

--- a/src/worker.py
+++ b/src/worker.py
@@ -91,7 +91,8 @@ class Worker:
     # Implementation derived from https://github.com/luxonis/depthai-experiments/tree/master/gen2-syncing#message-syncing
     # msgs maps frame sequence number to a dictionary that maps frame_type (i.e. color or depth) to a data packet
     msgs: Dict[int, Dict[str, BasePacket]] = dict()
-    def add_msg(self, msg: BasePacket, frame_type: str, seq = None):
+
+    def add_msg(self, msg: BasePacket, frame_type: str, seq=None):
         if seq is None:
             seq = msg.get_sequence_num()
         seq = str(seq)
@@ -100,14 +101,16 @@ class Worker:
         self.msgs[seq][frame_type] = msg
 
     def get_msgs(self):
-        seqs_to_remove = [] # Arr of sequence numbers to get deleted
+        seqs_to_remove = []  # Arr of sequence numbers to get deleted
         for seq, sync_msgs in self.msgs.items():
-            seqs_to_remove.append(seq) # Will get removed from dict if we find synced msgs pair
+            seqs_to_remove.append(
+                seq
+            )  # Will get removed from dict if we find synced msgs pair
             # Check if we have both detections and color frame with this sequence number
-            if len(sync_msgs) == 2: # has both color and depth
+            if len(sync_msgs) == 2:  # has both color and depth
                 for seq_to_remove in seqs_to_remove:
                     del self.msgs[seq_to_remove]
-                return sync_msgs # Returned synced msgs
+                return sync_msgs  # Returned synced msgs
         return None
 
     def __init__(
@@ -174,7 +177,9 @@ class Worker:
 
         color_output, depth_output = color_and_depth_output
         timestamp = time.time()
-        return CapturedData(color_output, timestamp), CapturedData(depth_output, timestamp)
+        return CapturedData(color_output, timestamp), CapturedData(
+            depth_output, timestamp
+        )
 
     async def get_color_image(self) -> CapturedData:
         while not self.color_image and self.running:
@@ -301,7 +306,9 @@ class Worker:
             return color
         return None
 
-    def _configure_stereo(self, color: Optional[CameraComponent]) -> Optional[StereoComponent]:
+    def _configure_stereo(
+        self, color: Optional[CameraComponent]
+    ) -> Optional[StereoComponent]:
         """
         Creates and configures stereo depth component— or doesn't
         (based on the config).

--- a/src/worker.py
+++ b/src/worker.py
@@ -106,6 +106,9 @@ class MessageSynchronizer:
             if len(sync_msgs) == 2:  # has both color and depth
                 return sync_msgs
         return None
+    
+    # def flush_msgs(self) -> None:
+    #     self.msgs.clear()
 
     def get_most_recent_color_msg(self) -> Optional[BasePacket]:
         return self._get_most_recent_msg("color")

--- a/src/worker.py
+++ b/src/worker.py
@@ -278,7 +278,6 @@ class Worker:
             if color:
                 # Ensures camera alignment and output resolution are same for color and depth
                 stereo.config_stereo(align=color)
-                stereo.node.setOutputSize(*color.node.getPreviewSize())
             self.oak.callback(stereo, callback=self._set_depth_map)
             return stereo
         return None
@@ -324,6 +323,7 @@ class Worker:
             packet (DisparityDepthPacket): outputted depth data inputted by caller
         """
         arr = packet.frame
+        # RSDK-5633: this is a major bottleneck for depth map retrieval
         if arr.shape[0] > self.height and arr.shape[1] > self.width:
             self.logger.debug(
                 f"Outputted depth map's shape is greater than specified in config: {arr.shape}; Manually resizing to {(self.height, self.width)}."

--- a/src/worker.py
+++ b/src/worker.py
@@ -243,7 +243,7 @@ class Worker:
             pcc = self._configure_pc(stereo, color)
             if pcc:
                 self.pc_q_handler = self.oak.queue(pcc, 5)
-    
+
         except Exception as e:
             msg = f"Error configuring OakCamera at stage '{stage}': {e}"
             resolution_err_substr = "bigger than maximum at current sensor resolution"


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-6633

Sorry for the confusing commit history! I made this branch off of a feature branch instead of main on accident. Please look at the final diff instead of commit-by-commit.

The main goal of this PR is to get rid of `time.time()` calls for timestamps. We want to use DepthAI's `get_timestamp` for better accuracy.

There are also some readability fixes.